### PR TITLE
Improved command packet listener

### DIFF
--- a/src/main/java/io/github/_4drian3d/unsignedvelocity/listener/packet/command/KeyedCommandListener.java
+++ b/src/main/java/io/github/_4drian3d/unsignedvelocity/listener/packet/command/KeyedCommandListener.java
@@ -2,35 +2,34 @@ package io.github._4drian3d.unsignedvelocity.listener.packet.command;
 
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.event.ResultedEvent;
+import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderV2;
 import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedPlayerCommand;
-import io.github._4drian3d.unsignedvelocity.listener.EventListener;
 import io.github._4drian3d.unsignedvelocity.UnSignedVelocity;
 import io.github._4drian3d.unsignedvelocity.configuration.Configuration;
+import io.github._4drian3d.unsignedvelocity.listener.EventListener;
 import io.github._4drian3d.vpacketevents.api.event.PacketReceiveEvent;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CompletableFuture;
 
-public class KeyedCommandListener implements EventListener {
-    private static final MethodHandle UNSIGNED_SETTER;
-    private static final MethodHandle SIGNED_PREVIEW;
-
-    static {
-        try {
-            final var lookup = MethodHandles.privateLookupIn(KeyedPlayerCommand.class, MethodHandles.lookup());
-            UNSIGNED_SETTER = lookup.findSetter(KeyedPlayerCommand.class, "unsigned", Boolean.TYPE);
-            SIGNED_PREVIEW = lookup.findSetter(KeyedPlayerCommand.class, "signedPreview", Boolean.TYPE);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
+public final class KeyedCommandListener implements EventListener, CommandHandler<KeyedPlayerCommand> {
     @Inject
     private Configuration configuration;
     @Inject
     private EventManager eventManager;
     @Inject
     private UnSignedVelocity plugin;
+    private final VelocityServer proxyServer;
+
+    @Inject
+    public KeyedCommandListener(final ProxyServer proxyServer) {
+        this.proxyServer = (VelocityServer) proxyServer;
+    }
 
     @Override
     public void register() {
@@ -42,19 +41,62 @@ public class KeyedCommandListener implements EventListener {
         return configuration.removeSignedCommandInformation();
     }
 
-    public void onCommand(PacketReceiveEvent event) {
-        if (event.getPacket() instanceof KeyedPlayerCommand) {
-            final KeyedPlayerCommand packet = (KeyedPlayerCommand) event.getPacket();
-
-            if (packet.isUnsigned()) {
-                return;
-            }
-            try {
-                UNSIGNED_SETTER.invoke(packet, true);
-                SIGNED_PREVIEW.invoke(packet, false);
-            } catch (Throwable e) {
-                throw new RuntimeException(e);
-            }
+    public void onCommand(final PacketReceiveEvent event) {
+        if (!(event.getPacket() instanceof KeyedPlayerCommand)) {
+            return;
         }
+
+        event.setResult(ResultedEvent.GenericResult.denied());
+
+        final KeyedPlayerCommand packet = (KeyedPlayerCommand) event.getPacket();
+        final ConnectedPlayer player = (ConnectedPlayer) event.getPlayer();
+        final String commandExecuted = packet.getCommand();
+
+        queueCommandResult(proxyServer, player, commandEvent -> {
+            final CommandExecuteEvent.CommandResult result = commandEvent.getResult();
+            if (result == CommandExecuteEvent.CommandResult.denied()) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            final String commandToRun = result.getCommand().orElse(commandExecuted);
+            if (result.isForwardToServer()) {
+                ChatBuilderV2 write = player.getChatBuilderFactory()
+                        .builder()
+                        .setTimestamp(packet.getTimestamp())
+                        .asPlayer(player);
+
+                if (commandToRun.equals(commandExecuted)) {
+                    return CompletableFuture.completedFuture(packet);
+                } else {
+                    write.message("/" + commandToRun);
+                }
+                return CompletableFuture.completedFuture(write.toServer());
+            }
+
+            return runCommand(proxyServer, player, commandToRun, hasRun -> {
+                if (hasRun) return null;
+
+                if (commandToRun.equals(packet.getCommand())) {
+                    return packet;
+                }
+
+                return player.getChatBuilderFactory()
+                        .builder()
+                        .setTimestamp(packet.getTimestamp())
+                        .asPlayer(player)
+                        .message("/" + commandToRun)
+                        .toServer();
+            });
+        }, packet.getCommand(), packet.getTimestamp());
+    }
+
+    @Override
+    public Class<KeyedPlayerCommand> packetClass() {
+        return KeyedPlayerCommand.class;
+    }
+
+    @Override
+    public void handlePlayerCommandInternal(KeyedPlayerCommand keyedPlayerCommand) {
+        //noop
     }
 }


### PR DESCRIPTION
Instead of using MethodHandles to set a packet as unsigned, the Velocity command handler is now replaced to avoid kicking out the user